### PR TITLE
Fixed ArgumentNullException from GetLockoutEndDateAsync

### DIFF
--- a/StackRedis.AspNet.Identity/RedisUserStore.IUserLockoutStore.cs
+++ b/StackRedis.AspNet.Identity/RedisUserStore.IUserLockoutStore.cs
@@ -44,6 +44,10 @@ namespace StackRedis.AspNet.Identity
         public virtual async Task<DateTimeOffset> GetLockoutEndDateAsync(TUser user)
         {
             string rawLockoutEndValue = await Database.HashGetAsync(UserLockDateHashKey, ((IUser)user).Id);
+
+            if (string.IsNullOrWhiteSpace(rawLockoutEndValue))
+              return DateTimeOffset.MinValue;
+
             long lockoutEndValue;
 
             if(long.TryParse(rawLockoutEndValue, out lockoutEndValue))


### PR DESCRIPTION
We encountered an issue when logging in. We were using the SPA template in Visual Studio 2013 and followed your directions.

Basically there is no lockout end date set so when it goes to parse it and the raw value is null or empty, it throws an ArgumentNullException.  We think the correct behavior is to check if it exists first.  This fixed our issue.
